### PR TITLE
Add mouse control and keyboard command enhancements

### DIFF
--- a/screenpipe-actions/Cargo.toml
+++ b/screenpipe-actions/Cargo.toml
@@ -25,3 +25,5 @@ enigo = "0.1.3"
 serde = { version = "1.0", features = ["derive"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+clipboard = "0.5"
+toml = "0.7"

--- a/screenpipe-actions/src/lib.rs
+++ b/screenpipe-actions/src/lib.rs
@@ -2,9 +2,17 @@ mod call_ai;
 mod monitor_keystroke_commands;
 mod run;
 mod screenshot;
-pub mod type_and_animate; 
+pub mod type_and_animate;
+mod config;
+mod history;
+mod status;
+mod clipboard;
 
 pub use call_ai::call_ai;
 pub use monitor_keystroke_commands::{run_keystroke_monitor, KeystrokeCommand};
 pub use run::run;
-pub use type_and_animate::{delete_characters, trigger_keyboard_permission, type_slowly}; // Export the run function from the run module
+pub use type_and_animate::{delete_characters, trigger_keyboard_permission, type_slowly};
+pub use config::*;
+pub use history::*;
+pub use status::*;
+pub use clipboard::*;

--- a/screenpipe-actions/src/monitor_keystroke_commands.rs
+++ b/screenpipe-actions/src/monitor_keystroke_commands.rs
@@ -7,7 +7,11 @@ use tracing::error;
 pub enum KeystrokeCommand {
     DoubleSlash,
     Stop,
-    // Add other commands as needed
+    CopySelection,
+    PasteClipboard,
+    UndoLastAction,
+    SaveFile,
+    FindInPage
 }
 
 pub struct KeystrokeMonitor {

--- a/screenpipe-actions/src/type_and_animate.rs
+++ b/screenpipe-actions/src/type_and_animate.rs
@@ -10,9 +10,14 @@ use tokio::time::{sleep, Duration};
 #[derive(Debug)]
 pub enum EnigoCommand {
     TypeCharacter(char),
-    TypeString(String),
+    TypeString(String), 
     DeleteCharacter,
     Shutdown,
+    MouseMove(i32, i32),
+    MouseClick(i32, i32),
+    MouseDrag(i32, i32),
+    MouseDoubleClick(i32, i32),
+    MouseRightClick(i32, i32)
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
This PR adds mouse control capabilities and extends keyboard command functionality. Changes include:

### New Mouse Controls
- Added new `EnigoCommand` variants for mouse operations:
  - MouseMove
  - MouseClick
  - MouseDrag
  - MouseDoubleClick
  - MouseRightClick
- Implemented mouse command handling in `TypeAndAnimate`

### Extended Keyboard Commands
- Added new `KeystrokeCommand` variants:
  - CopySelection
  - PasteClipboard
  - UndoLastAction
  - SaveFile
  - FindInPage

### New Modules
- Added new modules with supporting dependencies:
  - config
  - history
  - status
  - clipboard

### Dependencies
- Added clipboard = "0.5"
- Added toml = "0.7"

These changes enhance the application's input control capabilities and provide better user interaction support.